### PR TITLE
Scope server setup to a per-file before() not a global before

### DIFF
--- a/dummy.spec.ts
+++ b/dummy.spec.ts
@@ -1,7 +1,10 @@
 /// <reference types="cypress" />
-import { server } from "./server-client";
+import { getServer } from "./server-client";
 
 describe('Mockttp serves mocked responses', () => {
+
+  const server = getServer();
+
   it('to cy.request', () => {
     // This won't work because server has been started but this client instance
     // hasn't been configured with the port.

--- a/dummy2.spec.ts
+++ b/dummy2.spec.ts
@@ -1,7 +1,10 @@
 /// <reference types="cypress" />
-import { server } from "./server-client";
+import { getServer } from "./server-client";
 
 describe('Mockttp serves mocked responses', () => {
+
+  const server = getServer();
+
   it('to cy.request', () => {
     // This won't work because server has been started but this client instance
     // hasn't been configured with the port.

--- a/server-client.js
+++ b/server-client.js
@@ -4,12 +4,16 @@ export const server = getRemote({ standaloneServerUrl: 'http://localhost:1773' }
 
 console.log('registering before hook')
 
-before(async () => {
-  // Starts the server on a dynamic port. The port number that can later be
-  // retrieved as server.url
-  await server.start(8080)
-})
+export function getServer() {
+  before(async () => {
+    // Starts the server on a dynamic port. The port number that can later be
+    // retrieved as server.url
+    await server.start(8080)
+  })
 
-after(async () => {
-  await server.stop()
-})
+  after(async () => {
+    await server.stop()
+  })
+
+  return server
+};


### PR DESCRIPTION
I'm not really familiar with Cypress, but this appears to make the tests pass, and conceptually makes sense to me: rather than both tests registering a global hook (resulting in two global hooks that don't play nicely together) each test now registers its own local hook, and starts & stops its own independent server.

The server is started and stopped separately for each test file, but setup code is still be shared between files, and can potentially be preconfigured centrally with rules if necessary.

Does this work for your case?

I'll reply with a some broader thoughts on https://github.com/httptoolkit/mockttp/issues/52 in just a sec too.